### PR TITLE
Expose N8N webhook URL and improve dashboard error handling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -66,6 +66,7 @@ async function runAnalysis() {
         return;
       } catch (e) {}
     }
+    document.getElementById('output').textContent = err.message;
     document.getElementById('runStatus').textContent = 'Error';
   }
 }

--- a/public/config.js
+++ b/public/config.js
@@ -1,3 +1,3 @@
 // N8N webhook URL fallback for static hosting
 // Set this value during deployment if the backend is not available
-window.N8N_WEBHOOK_URL = '';
+window.N8N_WEBHOOK_URL = 'http://localhost:5678/webhook';


### PR DESCRIPTION
## Summary
- Configure default N8N webhook URL for static dashboard deployments
- Display detailed error messages in the Run Analysis output

## Testing
- `npm test`
- `curl -s http://localhost:3000/api/run` (with local stub webhook)


------
https://chatgpt.com/codex/tasks/task_e_68c3804163f883249ba70e1a902e9c2b